### PR TITLE
Aims to speed up `hash_salt` by using unlist vs Reduce

### DIFF
--- a/R/hbmPRNG.R
+++ b/R/hbmPRNG.R
@@ -67,6 +67,6 @@ hash_salt <- function(salt, ...) {
   # first, send all the `...` arguments to binary representation
   # HAEC SUNT DRACONES: leaves all error handling to `writeBin`
   # handling for empty ...?
-  binned <- Reduce(c, lapply(list(...), writeBin, con = raw()))
+  binned <- unlist(lapply(list(...), writeBin, con = raw()))
   return(.Call('_hbmPRNG_digest', salt, binned, PACKAGE = 'hbmPRNG'))
 }


### PR DESCRIPTION
As discussed in #2 this PR switches out `Reduce for `unlist`. I am not clear if this makes sense but everything appears to work on the face of it.